### PR TITLE
fix: noteCount列のラベルをNotesから総ノーツ数に変更

### DIFF
--- a/src/components/ChartTable.tsx
+++ b/src/components/ChartTable.tsx
@@ -82,7 +82,7 @@ export function ChartTable({ data, playMode }: ChartTableProps) {
       }),
       columnHelper.accessor('noteCount', {
         id: 'noteCount',
-        header: 'Notes',
+        header: '総ノーツ数',
         cell: (info) => info.getValue().toLocaleString(),
         size: 70,
         minSize: 70,

--- a/src/stores/columnStore.ts
+++ b/src/stores/columnStore.ts
@@ -26,7 +26,7 @@ export const COLUMN_CONFIGS: ColumnConfig[] = [
   { id: 'difficulty', label: '難易度', defaultVisible: true, defaultVisibleMobile: true },
   { id: 'level', label: 'Lv', defaultVisible: true, defaultVisibleMobile: true },
   { id: 'bpm', label: 'BPM', defaultVisible: true, defaultVisibleMobile: false },
-  { id: 'noteCount', label: 'Notes', defaultVisible: true, defaultVisibleMobile: false },
+  { id: 'noteCount', label: '総ノーツ数', defaultVisible: true, defaultVisibleMobile: false },
   { id: 'notes', label: 'NOTES', defaultVisible: true, defaultVisibleMobile: true },
   { id: 'peak', label: 'PEAK', defaultVisible: true, defaultVisibleMobile: true },
   { id: 'scratch', label: 'SCRATCH', defaultVisible: true, defaultVisibleMobile: true },


### PR DESCRIPTION
## 概要
一覧表のnoteCount列とレーダーNOTES列のラベルが紛らわしかったため、
noteCount列のラベルを「Notes」から「総ノーツ数」に変更しました。

## 変更内容
- `ChartTable.tsx`: テーブルヘッダーを `Notes` → `総ノーツ数` に変更
- `columnStore.ts`: カラム設定のラベルを `Notes` → `総ノーツ数` に変更

Closes #1