### PR TITLE
docs: READMEを整備

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,49 @@
-# React + Vite
+# IIDX Radar Viewer
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+beatmania IIDX の譜面別レーダー値を一覧・検索できる非公式ビューアです。
 
-Currently, two official plugins are available:
+https://freedom645.github.io/iidx-radar-viewer/
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) (or [oxc](https://oxc.rs) when used in [rolldown-vite](https://vite.dev/guide/rolldown)) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+## 機能
 
-## React Compiler
+- **譜面別レーダー値一覧表示** - SP/DP・難易度別にNOTES、PEAK、SCRATCH、SOF-LAN、CHARGE、CHORDのレーダー値を表示
+- **フィルタ機能** - 楽曲名、難易度、レベル、BPM、総ノーツ数、各レーダー値で絞り込み
+- **ソート機能** - 各カラムでソート可能
+- **統計情報表示** - 検索結果の平均・中央値・最小・最大を表示
+- **検索条件の保存** - フィルタ・ソート条件をLocalStorageに保存し、次回アクセス時に復元
+- **カラム表示設定** - 表示するカラムをカスタマイズ可能
 
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
+## 技術スタック
 
-## Expanding the ESLint configuration
+| カテゴリ | 技術 |
+|---------|------|
+| フレームワーク | React 19 + TypeScript |
+| ビルドツール | Vite |
+| スタイリング | Tailwind CSS |
+| テーブル | TanStack Table + TanStack Virtual |
+| データ取得 | axios |
+| 状態管理 | Zustand |
 
-If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+## セットアップ
+
+```bash
+# 依存関係のインストール
+npm install
+
+# 開発サーバーの起動
+npm run dev
+
+# ビルド
+npm run build
+
+# プレビュー
+npm run preview
+```
+
+## データソース
+
+譜面情報およびレーダー値は [IIDX-Data-Table](https://chinimuruhi.github.io/IIDX-Data-Table/) で公開されている情報を利用しています。
+
+## デプロイ
+
+GitHub Actions により `main` ブランチへのpush時に GitHub Pages へ自動デプロイされます。


### PR DESCRIPTION
## 概要
Viteテンプレートのデフォルトから、プロジェクト固有の内容に書き換えました。

## 追加内容
- プロジェクト概要とサイトURL
- 機能一覧
- 技術スタック
- セットアップ手順
- データソースの記載
- デプロイ方法

Closes #5