### PR TITLE
feat: カラムグループ化・検索条件連動・URLパラメータ化 (#19)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react'
+import { useEffect, useMemo, useRef, useState, useCallback } from 'react'
 import { useChartStore, useFilterStore } from '@/stores'
 import { PlayModeTabs, FilterPanel, ChartTable, ColumnSettings, StatsPanel } from '@/components'
 import { CPI_CLEAR_TYPES } from '@/types'
@@ -19,6 +19,21 @@ function App() {
   const { charts, loading, error, playMode, fetchCharts, setPlayMode } =
     useChartStore()
   useUrlSync()
+
+  const headerRef = useRef<HTMLElement>(null)
+  const [headerHeight, setHeaderHeight] = useState(0)
+
+  const updateHeaderHeight = useCallback(() => {
+    if (headerRef.current) {
+      setHeaderHeight(headerRef.current.offsetHeight)
+    }
+  }, [])
+
+  useEffect(() => {
+    updateHeaderHeight()
+    window.addEventListener('resize', updateHeaderHeight)
+    return () => window.removeEventListener('resize', updateHeaderHeight)
+  }, [updateHeaderHeight])
 
   const {
     searchText,
@@ -194,7 +209,7 @@ function App() {
   return (
     <div className="min-h-screen bg-gray-100">
       {/* ヘッダー */}
-      <header className="bg-white shadow-sm">
+      <header ref={headerRef} className="bg-white shadow-sm">
         <div className="max-w-7xl mx-auto px-4 py-4 flex items-center justify-between">
           <h1 className="text-xl font-bold text-gray-900">
             IIDX Radar Viewer
@@ -204,7 +219,7 @@ function App() {
       </header>
 
       {/* メインコンテンツ */}
-      <main className="max-w-7xl mx-auto px-4 py-6 flex flex-col" style={{ height: 'calc(100vh - 73px)' }}>
+      <main className="max-w-7xl mx-auto px-4 py-6 flex flex-col" style={{ height: headerHeight ? `calc(100vh - ${headerHeight}px)` : '100vh' }}>
         {/* フィルタパネル */}
         <div>
           <FilterPanel />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -195,20 +195,16 @@ function App() {
     <div className="min-h-screen bg-gray-100">
       {/* ヘッダー */}
       <header className="bg-white shadow-sm">
-        <div className="max-w-7xl mx-auto px-4 py-4">
+        <div className="max-w-7xl mx-auto px-4 py-4 flex items-center justify-between">
           <h1 className="text-xl font-bold text-gray-900">
             IIDX Radar Viewer
           </h1>
+          <PlayModeTabs value={playMode} onChange={setPlayMode} />
         </div>
       </header>
 
       {/* メインコンテンツ */}
       <main className="max-w-7xl mx-auto px-4 py-6">
-        {/* プレイモードタブ */}
-        <div className="bg-white rounded-t-lg shadow-sm">
-          <PlayModeTabs value={playMode} onChange={setPlayMode} />
-        </div>
-
         {/* フィルタパネル */}
         <div className="mt-4">
           <FilterPanel />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo } from 'react'
 import { useChartStore, useFilterStore } from '@/stores'
 import { PlayModeTabs, FilterPanel, ChartTable, ColumnSettings, StatsPanel } from '@/components'
 import { CPI_CLEAR_TYPES } from '@/types'
+import { useUrlSync } from '@/hooks'
 
 /** BPM文字列をパースして[min, max]を返す */
 function parseBpm(bpmStr: string): [number, number] {
@@ -17,6 +18,8 @@ function parseBpm(bpmStr: string): [number, number] {
 function App() {
   const { charts, loading, error, playMode, fetchCharts, setPlayMode } =
     useChartStore()
+  useUrlSync()
+
   const {
     searchText,
     difficulties,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -204,14 +204,14 @@ function App() {
       </header>
 
       {/* メインコンテンツ */}
-      <main className="max-w-7xl mx-auto px-4 py-6">
+      <main className="max-w-7xl mx-auto px-4 py-6 flex flex-col" style={{ height: 'calc(100vh - 73px)' }}>
         {/* フィルタパネル */}
-        <div className="mt-4">
+        <div>
           <FilterPanel />
         </div>
 
         {/* ツールバー */}
-        <div className="mt-4 flex items-center justify-between">
+        <div className="mt-3 flex items-center justify-between">
           <div className="text-sm text-gray-600">
             検索結果: <span className="font-medium">{filteredCharts.length}</span> 件
           </div>
@@ -219,10 +219,12 @@ function App() {
         </div>
 
         {/* 統計情報 */}
-        <StatsPanel data={filteredCharts} />
+        <div className="mt-3">
+          <StatsPanel data={filteredCharts} />
+        </div>
 
         {/* テーブル */}
-        <div className="mt-4 bg-white rounded-lg shadow-sm overflow-hidden">
+        <div className="mt-3 bg-white rounded-lg shadow-sm overflow-hidden flex-1 min-h-0">
           {loading ? (
             <div className="flex items-center justify-center py-12">
               <div className="flex items-center gap-3 text-gray-500">

--- a/src/components/ChartTable.tsx
+++ b/src/components/ChartTable.tsx
@@ -270,8 +270,7 @@ export function ChartTable({ data, playMode }: ChartTableProps) {
   return (
     <div
       ref={tableContainerRef}
-      className="overflow-auto"
-      style={{ height: 'calc(100vh - 350px)', minHeight: '400px' }}
+      className="overflow-auto h-full"
     >
       <table className="w-full divide-y divide-gray-200 table-fixed">
         <colgroup>

--- a/src/components/ColumnSettings.tsx
+++ b/src/components/ColumnSettings.tsx
@@ -1,15 +1,62 @@
-import { useState, useRef, useEffect, useMemo } from 'react'
-import { useChartStore, useColumnStore, COLUMN_CONFIGS } from '@/stores'
+import { useState, useRef, useEffect, useMemo, useCallback } from 'react'
+import { useChartStore, useColumnStore, COLUMN_CONFIGS, COLUMN_GROUPS } from '@/stores'
+import type { ColumnId } from '@/stores'
+
+function GroupCheckbox({
+  checked,
+  indeterminate,
+  onChange,
+  label,
+}: {
+  checked: boolean
+  indeterminate: boolean
+  onChange: () => void
+  label: string
+}) {
+  const ref = useCallback(
+    (el: HTMLInputElement | null) => {
+      if (el) {
+        el.indeterminate = indeterminate
+      }
+    },
+    [indeterminate]
+  )
+
+  return (
+    <label className="flex items-center gap-2 px-2 py-1.5 hover:bg-gray-50 rounded cursor-pointer font-medium">
+      <input
+        ref={ref}
+        type="checkbox"
+        checked={checked}
+        onChange={onChange}
+        className="rounded border-gray-300 text-blue-500 focus:ring-blue-500"
+      />
+      <span className="text-sm text-gray-800">{label}</span>
+    </label>
+  )
+}
 
 export function ColumnSettings() {
   const [isOpen, setIsOpen] = useState(false)
-  const { visibleColumns, toggleColumn } = useColumnStore()
+  const { visibleColumns, toggleColumn, setColumnsVisible } = useColumnStore()
   const { playMode } = useChartStore()
 
-  const filteredConfigs = useMemo(
-    () => COLUMN_CONFIGS.filter((c) => !c.playMode || c.playMode === playMode),
-    [playMode]
+  const configMap = useMemo(
+    () => new Map(COLUMN_CONFIGS.map((c) => [c.id, c])),
+    []
   )
+
+  const filteredGroups = useMemo(
+    () =>
+      COLUMN_GROUPS.map((group) => {
+        const columns = group.columnIds
+          .map((id) => configMap.get(id))
+          .filter((c) => c && (!c.playMode || c.playMode === playMode))
+        return { ...group, columns }
+      }).filter((g) => g.columns.length > 0),
+    [playMode, configMap]
+  )
+
   const containerRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
@@ -55,25 +102,54 @@ export function ColumnSettings() {
       </button>
 
       {isOpen && (
-        <div className="absolute right-0 mt-1 w-48 bg-white border border-gray-200 rounded-lg shadow-lg z-50">
+        <div className="absolute right-0 mt-1 w-56 bg-white border border-gray-200 rounded-lg shadow-lg z-50">
           <div className="p-2">
             <div className="text-xs text-gray-500 font-medium mb-2 px-2">
               表示するカラム
             </div>
-            {filteredConfigs.map((config) => (
-              <label
-                key={config.id}
-                className="flex items-center gap-2 px-2 py-1.5 hover:bg-gray-50 rounded cursor-pointer"
-              >
-                <input
-                  type="checkbox"
-                  checked={visibleColumns.has(config.id)}
-                  onChange={() => toggleColumn(config.id)}
-                  className="rounded border-gray-300 text-blue-500 focus:ring-blue-500"
-                />
-                <span className="text-sm text-gray-700">{config.label}</span>
-              </label>
-            ))}
+            {filteredGroups.map((group) => {
+              const groupColumnIds = group.columns.map((c) => c!.id)
+              const checkedCount = groupColumnIds.filter((id) =>
+                visibleColumns.has(id)
+              ).length
+              const allChecked = checkedCount === groupColumnIds.length
+              const noneChecked = checkedCount === 0
+              const indeterminate = !allChecked && !noneChecked
+
+              return (
+                <div key={group.id} className="mb-1">
+                  <GroupCheckbox
+                    checked={allChecked}
+                    indeterminate={indeterminate}
+                    onChange={() =>
+                      setColumnsVisible(
+                        groupColumnIds as ColumnId[],
+                        !allChecked
+                      )
+                    }
+                    label={group.label}
+                  />
+                  <div className="ml-4">
+                    {group.columns.map((config) => (
+                      <label
+                        key={config!.id}
+                        className="flex items-center gap-2 px-2 py-1 hover:bg-gray-50 rounded cursor-pointer"
+                      >
+                        <input
+                          type="checkbox"
+                          checked={visibleColumns.has(config!.id)}
+                          onChange={() => toggleColumn(config!.id)}
+                          className="rounded border-gray-300 text-blue-500 focus:ring-blue-500"
+                        />
+                        <span className="text-sm text-gray-700">
+                          {config!.label}
+                        </span>
+                      </label>
+                    ))}
+                  </div>
+                </div>
+              )
+            })}
           </div>
         </div>
       )}

--- a/src/components/ColumnSettings.tsx
+++ b/src/components/ColumnSettings.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect, useMemo, useCallback } from 'react'
 import { useChartStore, useColumnStore, COLUMN_CONFIGS, COLUMN_GROUPS } from '@/stores'
-import type { ColumnId } from '@/stores'
+import type { ColumnConfig } from '@/stores'
 
 function GroupCheckbox({
   checked,
@@ -51,7 +51,7 @@ export function ColumnSettings() {
       COLUMN_GROUPS.map((group) => {
         const columns = group.columnIds
           .map((id) => configMap.get(id))
-          .filter((c) => c && (!c.playMode || c.playMode === playMode))
+          .filter((c): c is ColumnConfig => c != null && (!c.playMode || c.playMode === playMode))
         return { ...group, columns }
       }).filter((g) => g.columns.length > 0),
     [playMode, configMap]
@@ -108,7 +108,7 @@ export function ColumnSettings() {
               表示するカラム
             </div>
             {filteredGroups.map((group) => {
-              const groupColumnIds = group.columns.map((c) => c!.id)
+              const groupColumnIds = group.columns.map((c) => c.id)
               const checkedCount = groupColumnIds.filter((id) =>
                 visibleColumns.has(id)
               ).length
@@ -122,27 +122,24 @@ export function ColumnSettings() {
                     checked={allChecked}
                     indeterminate={indeterminate}
                     onChange={() =>
-                      setColumnsVisible(
-                        groupColumnIds as ColumnId[],
-                        !allChecked
-                      )
+                      setColumnsVisible(groupColumnIds, !allChecked)
                     }
                     label={group.label}
                   />
                   <div className="ml-4">
                     {group.columns.map((config) => (
                       <label
-                        key={config!.id}
+                        key={config.id}
                         className="flex items-center gap-2 px-2 py-1 hover:bg-gray-50 rounded cursor-pointer"
                       >
                         <input
                           type="checkbox"
-                          checked={visibleColumns.has(config!.id)}
-                          onChange={() => toggleColumn(config!.id)}
+                          checked={visibleColumns.has(config.id)}
+                          onChange={() => toggleColumn(config.id)}
                           className="rounded border-gray-300 text-blue-500 focus:ring-blue-500"
                         />
                         <span className="text-sm text-gray-700">
-                          {config!.label}
+                          {config.label}
                         </span>
                       </label>
                     ))}

--- a/src/components/FilterPanel.tsx
+++ b/src/components/FilterPanel.tsx
@@ -62,6 +62,8 @@ export function FilterPanel() {
     toggleCpiFilterExpanded,
     showHiddenFilters,
     toggleShowHiddenFilters,
+    filterPanelExpanded,
+    toggleFilterPanelExpanded,
     resetFilters,
   } = useFilterStore()
 
@@ -86,139 +88,160 @@ export function FilterPanel() {
   }, [showHiddenFilters, visibleColumns])
 
   return (
-    <div className="bg-white border border-gray-200 rounded-lg p-4 space-y-4">
-      {/* 非表示項目も検索する */}
-      <label className="flex items-center gap-2 cursor-pointer">
-        <input
-          type="checkbox"
-          checked={showHiddenFilters}
-          onChange={toggleShowHiddenFilters}
-          className="rounded border-gray-300 text-blue-500 focus:ring-blue-500"
-        />
-        <span className="text-xs text-gray-600">非表示カラムの検索条件も表示する</span>
-      </label>
-
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-        {/* 楽曲名検索（常に表示） */}
-        <div>
-          <label className="block text-xs text-gray-600 mb-1">楽曲名検索</label>
-          <SearchInput value={searchText} onChange={setSearchText} />
-        </div>
-
-        {/* 難易度フィルタ */}
-        {isFilterVisible.difficulty && (
-          <div>
-            <label className="block text-xs text-gray-600 mb-1">難易度</label>
-            <DifficultyFilter
-              selected={difficulties}
-              onToggle={toggleDifficulty}
-            />
-          </div>
-        )}
-
-        {/* レベルフィルタ */}
-        {isFilterVisible.level && (
-          <div>
-            <label className="block text-xs text-gray-600 mb-1">レベル</label>
-            <LevelFilter
-              min={levelMin}
-              max={levelMax}
-              onChange={setLevelRange}
-            />
-          </div>
-        )}
-
-        {/* BPMフィルタ */}
-        {isFilterVisible.bpm && (
-          <div>
-            <label className="block text-xs text-gray-600 mb-1">BPM</label>
-            <NumberRangeFilter
-              min={bpmMin}
-              max={bpmMax}
-              onChange={setBpmRange}
-            />
-          </div>
-        )}
-
-        {/* 総ノーツ数フィルタ */}
-        {isFilterVisible.noteCount && (
-          <div>
-            <label className="block text-xs text-gray-600 mb-1">総ノーツ数</label>
-            <NumberRangeFilter
-              min={noteCountMin}
-              max={noteCountMax}
-              onChange={setNoteCountRange}
-              inputMin={1}
-              inputMax={9999}
-            />
-          </div>
-        )}
-
-        {/* 収録状況フィルタ（常に表示） */}
-        <div>
-          <label className="block text-xs text-gray-600 mb-1">収録状況</label>
-          <VersionFilter
-            value={versionFilter}
-            onChange={setVersionFilter}
-          />
-        </div>
-
-        {/* INFINITAS楽曲パックフィルタ（常に表示） */}
-        <div>
-          <label className="block text-xs text-gray-600 mb-1">INFINITAS楽曲パック</label>
-          <PackFilter
-            labels={labels}
-            selectedPackIds={selectedPackIds}
-            onToggle={togglePackId}
-          />
-        </div>
-      </div>
-
-      {/* レーダ値フィルタ */}
-      {isFilterVisible.radar && (
-        <RadarFilter
-          filters={radarFilters}
-          onChange={setRadarFilter}
-          expanded={radarFilterExpanded}
-          onToggleExpanded={toggleRadarFilterExpanded}
-        />
-      )}
-
-      {/* 難易度表フィルタ */}
-      {isFilterVisible.difficultyTable && (
-        <DifficultyTableFilter
-          playMode={playMode}
-          selectedSpNormalKeys={selectedSpNormalKeys}
-          selectedSpHardKeys={selectedSpHardKeys}
-          dpFilter={dpDifficultyFilter}
-          spLabels={spDifficultyLabels}
-          onToggleSpNormal={toggleSpNormalKey}
-          onToggleSpHard={toggleSpHardKey}
-          onDpChange={setDpDifficultyFilter}
-          expanded={difficultyTableFilterExpanded}
-          onToggleExpanded={toggleDifficultyTableFilterExpanded}
-        />
-      )}
-
-      {/* CPIフィルタ（SPモードのみ） */}
-      {playMode === 'SP' && isFilterVisible.cpi && (
-        <CpiFilter
-          filters={cpiFilters}
-          onChange={setCpiFilter}
-          expanded={cpiFilterExpanded}
-          onToggleExpanded={toggleCpiFilterExpanded}
-        />
-      )}
-
-      {/* リセットボタン */}
-      <div className="flex justify-end">
-        <button
-          onClick={resetFilters}
-          className="px-4 py-2 text-sm text-gray-600 bg-gray-100 hover:bg-gray-200 rounded transition-colors"
+    <div className="bg-white border border-gray-200 rounded-lg">
+      {/* ヘッダー（常に表示） */}
+      <button
+        onClick={toggleFilterPanelExpanded}
+        className="w-full flex items-center justify-between px-4 py-3 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors rounded-lg"
+      >
+        <span>検索条件</span>
+        <svg
+          className={`w-4 h-4 transition-transform ${filterPanelExpanded ? 'rotate-180' : ''}`}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
         >
-          リセット
-        </button>
-      </div>
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+
+      {/* パネル本体 */}
+      {filterPanelExpanded && (
+        <div className="px-4 pb-4 space-y-4 border-t border-gray-200">
+          {/* 非表示項目も検索する */}
+          <label className="flex items-center gap-2 cursor-pointer pt-3">
+            <input
+              type="checkbox"
+              checked={showHiddenFilters}
+              onChange={toggleShowHiddenFilters}
+              className="rounded border-gray-300 text-blue-500 focus:ring-blue-500"
+            />
+            <span className="text-xs text-gray-600">非表示カラムの検索条件も表示する</span>
+          </label>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+            {/* 楽曲名検索（常に表示） */}
+            <div>
+              <label className="block text-xs text-gray-600 mb-1">楽曲名検索</label>
+              <SearchInput value={searchText} onChange={setSearchText} />
+            </div>
+
+            {/* 難易度フィルタ */}
+            {isFilterVisible.difficulty && (
+              <div>
+                <label className="block text-xs text-gray-600 mb-1">難易度</label>
+                <DifficultyFilter
+                  selected={difficulties}
+                  onToggle={toggleDifficulty}
+                />
+              </div>
+            )}
+
+            {/* レベルフィルタ */}
+            {isFilterVisible.level && (
+              <div>
+                <label className="block text-xs text-gray-600 mb-1">レベル</label>
+                <LevelFilter
+                  min={levelMin}
+                  max={levelMax}
+                  onChange={setLevelRange}
+                />
+              </div>
+            )}
+
+            {/* BPMフィルタ */}
+            {isFilterVisible.bpm && (
+              <div>
+                <label className="block text-xs text-gray-600 mb-1">BPM</label>
+                <NumberRangeFilter
+                  min={bpmMin}
+                  max={bpmMax}
+                  onChange={setBpmRange}
+                />
+              </div>
+            )}
+
+            {/* 総ノーツ数フィルタ */}
+            {isFilterVisible.noteCount && (
+              <div>
+                <label className="block text-xs text-gray-600 mb-1">総ノーツ数</label>
+                <NumberRangeFilter
+                  min={noteCountMin}
+                  max={noteCountMax}
+                  onChange={setNoteCountRange}
+                  inputMin={1}
+                  inputMax={9999}
+                />
+              </div>
+            )}
+
+            {/* 収録状況フィルタ（常に表示） */}
+            <div>
+              <label className="block text-xs text-gray-600 mb-1">収録状況</label>
+              <VersionFilter
+                value={versionFilter}
+                onChange={setVersionFilter}
+              />
+            </div>
+
+            {/* INFINITAS楽曲パックフィルタ（常に表示） */}
+            <div>
+              <label className="block text-xs text-gray-600 mb-1">INFINITAS楽曲パック</label>
+              <PackFilter
+                labels={labels}
+                selectedPackIds={selectedPackIds}
+                onToggle={togglePackId}
+              />
+            </div>
+          </div>
+
+          {/* レーダ値フィルタ */}
+          {isFilterVisible.radar && (
+            <RadarFilter
+              filters={radarFilters}
+              onChange={setRadarFilter}
+              expanded={radarFilterExpanded}
+              onToggleExpanded={toggleRadarFilterExpanded}
+            />
+          )}
+
+          {/* 難易度表フィルタ */}
+          {isFilterVisible.difficultyTable && (
+            <DifficultyTableFilter
+              playMode={playMode}
+              selectedSpNormalKeys={selectedSpNormalKeys}
+              selectedSpHardKeys={selectedSpHardKeys}
+              dpFilter={dpDifficultyFilter}
+              spLabels={spDifficultyLabels}
+              onToggleSpNormal={toggleSpNormalKey}
+              onToggleSpHard={toggleSpHardKey}
+              onDpChange={setDpDifficultyFilter}
+              expanded={difficultyTableFilterExpanded}
+              onToggleExpanded={toggleDifficultyTableFilterExpanded}
+            />
+          )}
+
+          {/* CPIフィルタ（SPモードのみ） */}
+          {playMode === 'SP' && isFilterVisible.cpi && (
+            <CpiFilter
+              filters={cpiFilters}
+              onChange={setCpiFilter}
+              expanded={cpiFilterExpanded}
+              onToggleExpanded={toggleCpiFilterExpanded}
+            />
+          )}
+
+          {/* リセットボタン */}
+          <div className="flex justify-end">
+            <button
+              onClick={resetFilters}
+              className="px-4 py-2 text-sm text-gray-600 bg-gray-100 hover:bg-gray-200 rounded transition-colors"
+            >
+              リセット
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/components/FilterPanel.tsx
+++ b/src/components/FilterPanel.tsx
@@ -11,8 +11,11 @@ import { VersionFilter } from './VersionFilter'
 import { DifficultyTableFilter } from './DifficultyTableFilter'
 import { CpiFilter } from './CpiFilter'
 
+/** フィルタセクションのキー */
+type FilterSectionKey = 'difficulty' | 'level' | 'bpm' | 'noteCount' | 'radar' | 'difficultyTable' | 'cpi'
+
 /** フィルタセクションと対応カラムのマッピング */
-const FILTER_COLUMN_MAP: Record<string, ColumnId[]> = {
+const FILTER_COLUMN_MAP: Record<FilterSectionKey, ColumnId[]> = {
   difficulty: ['difficulty'],
   level: ['level'],
   bpm: ['bpm'],
@@ -70,11 +73,9 @@ export function FilterPanel() {
   const { visibleColumns } = useColumnStore()
 
   const isFilterVisible = useMemo(() => {
-    const check = (key: string): boolean => {
+    const check = (key: FilterSectionKey): boolean => {
       if (showHiddenFilters) return true
-      const columns = FILTER_COLUMN_MAP[key]
-      if (!columns) return true
-      return columns.some((col) => visibleColumns.has(col))
+      return FILTER_COLUMN_MAP[key].some((col) => visibleColumns.has(col))
     }
     return {
       difficulty: check('difficulty'),

--- a/src/components/FilterPanel.tsx
+++ b/src/components/FilterPanel.tsx
@@ -1,4 +1,6 @@
-import { useChartStore, useFilterStore } from '@/stores'
+import { useMemo } from 'react'
+import { useChartStore, useFilterStore, useColumnStore } from '@/stores'
+import type { ColumnId } from '@/stores'
 import { SearchInput } from './SearchInput'
 import { DifficultyFilter } from './DifficultyFilter'
 import { LevelFilter } from './LevelFilter'
@@ -8,6 +10,17 @@ import { PackFilter } from './PackFilter'
 import { VersionFilter } from './VersionFilter'
 import { DifficultyTableFilter } from './DifficultyTableFilter'
 import { CpiFilter } from './CpiFilter'
+
+/** フィルタセクションと対応カラムのマッピング */
+const FILTER_COLUMN_MAP: Record<string, ColumnId[]> = {
+  difficulty: ['difficulty'],
+  level: ['level'],
+  bpm: ['bpm'],
+  noteCount: ['noteCount'],
+  radar: ['notes', 'peak', 'scratch', 'soflan', 'charge', 'chord'],
+  difficultyTable: ['spNormal', 'spHard', 'dpDifficulty'],
+  cpi: ['cpiEasy', 'cpiNormal', 'cpiHard', 'cpiExh', 'cpiFc'],
+}
 
 export function FilterPanel() {
   const { playMode } = useChartStore()
@@ -47,60 +60,101 @@ export function FilterPanel() {
     setCpiFilter,
     cpiFilterExpanded,
     toggleCpiFilterExpanded,
+    showHiddenFilters,
+    toggleShowHiddenFilters,
     resetFilters,
   } = useFilterStore()
 
+  const { visibleColumns } = useColumnStore()
+
+  const isFilterVisible = useMemo(() => {
+    const check = (key: string): boolean => {
+      if (showHiddenFilters) return true
+      const columns = FILTER_COLUMN_MAP[key]
+      if (!columns) return true
+      return columns.some((col) => visibleColumns.has(col))
+    }
+    return {
+      difficulty: check('difficulty'),
+      level: check('level'),
+      bpm: check('bpm'),
+      noteCount: check('noteCount'),
+      radar: check('radar'),
+      difficultyTable: check('difficultyTable'),
+      cpi: check('cpi'),
+    }
+  }, [showHiddenFilters, visibleColumns])
+
   return (
     <div className="bg-white border border-gray-200 rounded-lg p-4 space-y-4">
+      {/* 非表示項目も検索する */}
+      <label className="flex items-center gap-2 cursor-pointer">
+        <input
+          type="checkbox"
+          checked={showHiddenFilters}
+          onChange={toggleShowHiddenFilters}
+          className="rounded border-gray-300 text-blue-500 focus:ring-blue-500"
+        />
+        <span className="text-xs text-gray-600">非表示カラムの検索条件も表示する</span>
+      </label>
+
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-        {/* 楽曲名検索 */}
+        {/* 楽曲名検索（常に表示） */}
         <div>
           <label className="block text-xs text-gray-600 mb-1">楽曲名検索</label>
           <SearchInput value={searchText} onChange={setSearchText} />
         </div>
 
         {/* 難易度フィルタ */}
-        <div>
-          <label className="block text-xs text-gray-600 mb-1">難易度</label>
-          <DifficultyFilter
-            selected={difficulties}
-            onToggle={toggleDifficulty}
-          />
-        </div>
+        {isFilterVisible.difficulty && (
+          <div>
+            <label className="block text-xs text-gray-600 mb-1">難易度</label>
+            <DifficultyFilter
+              selected={difficulties}
+              onToggle={toggleDifficulty}
+            />
+          </div>
+        )}
 
         {/* レベルフィルタ */}
-        <div>
-          <label className="block text-xs text-gray-600 mb-1">レベル</label>
-          <LevelFilter
-            min={levelMin}
-            max={levelMax}
-            onChange={setLevelRange}
-          />
-        </div>
+        {isFilterVisible.level && (
+          <div>
+            <label className="block text-xs text-gray-600 mb-1">レベル</label>
+            <LevelFilter
+              min={levelMin}
+              max={levelMax}
+              onChange={setLevelRange}
+            />
+          </div>
+        )}
 
         {/* BPMフィルタ */}
-        <div>
-          <label className="block text-xs text-gray-600 mb-1">BPM</label>
-          <NumberRangeFilter
-            min={bpmMin}
-            max={bpmMax}
-            onChange={setBpmRange}
-          />
-        </div>
+        {isFilterVisible.bpm && (
+          <div>
+            <label className="block text-xs text-gray-600 mb-1">BPM</label>
+            <NumberRangeFilter
+              min={bpmMin}
+              max={bpmMax}
+              onChange={setBpmRange}
+            />
+          </div>
+        )}
 
         {/* 総ノーツ数フィルタ */}
-        <div>
-          <label className="block text-xs text-gray-600 mb-1">総ノーツ数</label>
-          <NumberRangeFilter
-            min={noteCountMin}
-            max={noteCountMax}
-            onChange={setNoteCountRange}
-            inputMin={1}
-            inputMax={9999}
-          />
-        </div>
+        {isFilterVisible.noteCount && (
+          <div>
+            <label className="block text-xs text-gray-600 mb-1">総ノーツ数</label>
+            <NumberRangeFilter
+              min={noteCountMin}
+              max={noteCountMax}
+              onChange={setNoteCountRange}
+              inputMin={1}
+              inputMax={9999}
+            />
+          </div>
+        )}
 
-        {/* 収録状況フィルタ */}
+        {/* 収録状況フィルタ（常に表示） */}
         <div>
           <label className="block text-xs text-gray-600 mb-1">収録状況</label>
           <VersionFilter
@@ -109,7 +163,7 @@ export function FilterPanel() {
           />
         </div>
 
-        {/* INFINITAS楽曲パックフィルタ */}
+        {/* INFINITAS楽曲パックフィルタ（常に表示） */}
         <div>
           <label className="block text-xs text-gray-600 mb-1">INFINITAS楽曲パック</label>
           <PackFilter
@@ -121,29 +175,33 @@ export function FilterPanel() {
       </div>
 
       {/* レーダ値フィルタ */}
-      <RadarFilter
-        filters={radarFilters}
-        onChange={setRadarFilter}
-        expanded={radarFilterExpanded}
-        onToggleExpanded={toggleRadarFilterExpanded}
-      />
+      {isFilterVisible.radar && (
+        <RadarFilter
+          filters={radarFilters}
+          onChange={setRadarFilter}
+          expanded={radarFilterExpanded}
+          onToggleExpanded={toggleRadarFilterExpanded}
+        />
+      )}
 
       {/* 難易度表フィルタ */}
-      <DifficultyTableFilter
-        playMode={playMode}
-        selectedSpNormalKeys={selectedSpNormalKeys}
-        selectedSpHardKeys={selectedSpHardKeys}
-        dpFilter={dpDifficultyFilter}
-        spLabels={spDifficultyLabels}
-        onToggleSpNormal={toggleSpNormalKey}
-        onToggleSpHard={toggleSpHardKey}
-        onDpChange={setDpDifficultyFilter}
-        expanded={difficultyTableFilterExpanded}
-        onToggleExpanded={toggleDifficultyTableFilterExpanded}
-      />
+      {isFilterVisible.difficultyTable && (
+        <DifficultyTableFilter
+          playMode={playMode}
+          selectedSpNormalKeys={selectedSpNormalKeys}
+          selectedSpHardKeys={selectedSpHardKeys}
+          dpFilter={dpDifficultyFilter}
+          spLabels={spDifficultyLabels}
+          onToggleSpNormal={toggleSpNormalKey}
+          onToggleSpHard={toggleSpHardKey}
+          onDpChange={setDpDifficultyFilter}
+          expanded={difficultyTableFilterExpanded}
+          onToggleExpanded={toggleDifficultyTableFilterExpanded}
+        />
+      )}
 
       {/* CPIフィルタ（SPモードのみ） */}
-      {playMode === 'SP' && (
+      {playMode === 'SP' && isFilterVisible.cpi && (
         <CpiFilter
           filters={cpiFilters}
           onChange={setCpiFilter}

--- a/src/components/PlayModeTabs.tsx
+++ b/src/components/PlayModeTabs.tsx
@@ -9,15 +9,15 @@ export function PlayModeTabs({ value, onChange }: PlayModeTabsProps) {
   const modes: PlayMode[] = ['SP', 'DP']
 
   return (
-    <div className="flex border-b border-gray-200">
+    <div className="flex rounded-md overflow-hidden border border-gray-200">
       {modes.map((mode) => (
         <button
           key={mode}
           onClick={() => onChange(mode)}
-          className={`px-6 py-3 text-sm font-medium transition-colors ${
+          className={`px-4 py-1.5 text-sm font-medium transition-colors ${
             value === mode
-              ? 'border-b-2 border-blue-500 text-blue-600 bg-blue-50'
-              : 'text-gray-500 hover:text-gray-700 hover:bg-gray-50'
+              ? 'bg-blue-500 text-white'
+              : 'bg-white text-gray-600 hover:bg-gray-50'
           }`}
         >
           {mode}

--- a/src/components/StatsPanel.tsx
+++ b/src/components/StatsPanel.tsx
@@ -71,17 +71,27 @@ export function StatsPanel({ data }: StatsPanelProps) {
   ]
 
   return (
-    <div className="mt-2">
+    <div className="bg-white border border-gray-200 rounded-lg">
+      {/* ヘッダー */}
       <button
         onClick={() => setExpanded(!expanded)}
-        className="text-sm text-blue-600 hover:text-blue-800 flex items-center gap-1"
+        className="w-full flex items-center justify-between px-4 py-3 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors rounded-lg"
       >
-        <span>{expanded ? '▼' : '▶'}</span>
         <span>統計情報</span>
+        <svg
+          className={`w-4 h-4 transition-transform ${expanded ? 'rotate-180' : ''}`}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
       </button>
+
+      {/* パネル本体 */}
       {expanded && (
-        <div className="mt-2 bg-white border border-gray-200 rounded-lg p-4 overflow-x-auto">
-          <table className="w-full text-sm">
+        <div className="px-4 pb-4 border-t border-gray-200 overflow-x-auto">
+          <table className="w-full text-sm mt-3">
             <thead>
               <tr className="text-left text-xs text-gray-500 border-b">
                 <th className="pb-2 pr-4">項目</th>

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export { useLocalStorage } from './useLocalStorage'
+export { useUrlSync } from './useUrlSync'

--- a/src/hooks/useUrlSync.ts
+++ b/src/hooks/useUrlSync.ts
@@ -241,18 +241,11 @@ function restoreFromUrl(params: URLSearchParams): boolean {
   // SP difficulty table
   const spn = params.get('spn')
   if (spn !== null) {
-    // Reset then set each key
-    const keys = spn.split(',')
-    for (const key of keys) {
-      filter.toggleSpNormalKey(key)
-    }
+    filter.setSelectedSpNormalKeys(new Set(spn.split(',')))
   }
   const sph = params.get('sph')
   if (sph !== null) {
-    const keys = sph.split(',')
-    for (const key of keys) {
-      filter.toggleSpHardKey(key)
-    }
+    filter.setSelectedSpHardKeys(new Set(sph.split(',')))
   }
 
   // DP difficulty
@@ -283,11 +276,12 @@ function restoreFromUrl(params: URLSearchParams): boolean {
   // visible columns
   const cols = params.get('cols')
   if (cols !== null) {
-    const colIds = new Set(cols.split(',').filter(Boolean)) as Set<ColumnId>
-    // Set all columns: first hide all, then show specified ones
-    const allIds = COLUMN_CONFIGS.map((c) => c.id)
-    for (const id of allIds) {
-      column.setColumnVisible(id, colIds.has(id as ColumnId))
+    const validColumnIds = new Set<ColumnId>(COLUMN_CONFIGS.map((c) => c.id))
+    const colIds = new Set(
+      cols.split(',').filter((id): id is ColumnId => validColumnIds.has(id as ColumnId))
+    )
+    for (const id of validColumnIds) {
+      column.setColumnVisible(id, colIds.has(id))
     }
   }
 
@@ -328,8 +322,9 @@ export function useUrlSync() {
         rafIdRef.current = null
         const params = buildSearchParams()
         const search = params.toString()
-        const newUrl = search ? `${window.location.pathname}?${search}` : window.location.pathname
-        if (window.location.search !== `?${search}` && window.location.search !== (search ? `?${search}` : '')) {
+        const currentSearch = window.location.search.slice(1)
+        if (currentSearch !== search) {
+          const newUrl = search ? `${window.location.pathname}?${search}` : window.location.pathname
           window.history.replaceState(null, '', newUrl)
         }
       })

--- a/src/hooks/useUrlSync.ts
+++ b/src/hooks/useUrlSync.ts
@@ -1,0 +1,352 @@
+import { useLayoutEffect, useRef } from 'react'
+import { useChartStore } from '@/stores/chartStore'
+import { useFilterStore } from '@/stores/filterStore'
+import { useColumnStore, COLUMN_CONFIGS } from '@/stores/columnStore'
+import { useSortStore } from '@/stores/sortStore'
+import type { ColumnId } from '@/stores/columnStore'
+import type { PlayMode, Difficulty, VersionFilter, CpiClearType } from '@/types'
+import { CPI_CLEAR_TYPES, DIFFICULTIES } from '@/types'
+
+const RADAR_TYPES_KEYS = ['notes', 'peak', 'scratch', 'soflan', 'charge', 'chord'] as const
+
+/** デフォルト値（URLに含めないための比較用） */
+const DEFAULTS = {
+  playMode: 'SP' as PlayMode,
+  searchText: '',
+  difficulties: new Set<Difficulty>(DIFFICULTIES),
+  levelMin: 1,
+  levelMax: 12,
+  bpmMin: '',
+  bpmMax: '',
+  noteCountMin: '',
+  noteCountMax: '',
+  radarMin: 0,
+  radarMax: 200,
+  versionFilter: 'all' as VersionFilter,
+  selectedPackIds: new Set<number>(),
+  selectedSpNormalKeys: new Set<string>(),
+  selectedSpHardKeys: new Set<string>(),
+  dpDifficultyMin: '',
+  dpDifficultyMax: '',
+  cpiMin: '',
+  cpiMax: '',
+  showHiddenFilters: false,
+}
+
+const defaultVisibleColumns = new Set(
+  COLUMN_CONFIGS.filter((c) => c.defaultVisible).map((c) => c.id)
+)
+
+/** 難易度の略称マッピング */
+const DIFFICULTY_SHORT_MAP: Record<string, Difficulty> = {
+  B: 'BEGINNER',
+  N: 'NORMAL',
+  H: 'HYPER',
+  A: 'ANOTHER',
+  L: 'LEGGENDARIA',
+}
+const DIFFICULTY_TO_SHORT: Record<Difficulty, string> = {
+  BEGINNER: 'B',
+  NORMAL: 'N',
+  HYPER: 'H',
+  ANOTHER: 'A',
+  LEGGENDARIA: 'L',
+}
+
+function setsEqual<T>(a: Set<T>, b: Set<T>): boolean {
+  if (a.size !== b.size) return false
+  for (const item of a) {
+    if (!b.has(item)) return false
+  }
+  return true
+}
+
+/** 現在の状態からURLパラメータを構築 */
+function buildSearchParams(): URLSearchParams {
+  const params = new URLSearchParams()
+  const chart = useChartStore.getState()
+  const filter = useFilterStore.getState()
+  const column = useColumnStore.getState()
+  const sort = useSortStore.getState()
+
+  // playMode
+  if (chart.playMode !== DEFAULTS.playMode) {
+    params.set('pm', chart.playMode)
+  }
+
+  // searchText
+  if (filter.searchText !== DEFAULTS.searchText) {
+    params.set('q', filter.searchText)
+  }
+
+  // difficulties
+  if (!setsEqual(filter.difficulties, DEFAULTS.difficulties)) {
+    const shorts = Array.from(filter.difficulties).map((d) => DIFFICULTY_TO_SHORT[d])
+    params.set('d', shorts.join(','))
+  }
+
+  // level range
+  if (filter.levelMin !== DEFAULTS.levelMin || filter.levelMax !== DEFAULTS.levelMax) {
+    params.set('lv', `${filter.levelMin}-${filter.levelMax}`)
+  }
+
+  // BPM range
+  if (filter.bpmMin !== DEFAULTS.bpmMin || filter.bpmMax !== DEFAULTS.bpmMax) {
+    params.set('bpm', `${filter.bpmMin}-${filter.bpmMax}`)
+  }
+
+  // noteCount range
+  if (filter.noteCountMin !== DEFAULTS.noteCountMin || filter.noteCountMax !== DEFAULTS.noteCountMax) {
+    params.set('nc', `${filter.noteCountMin}-${filter.noteCountMax}`)
+  }
+
+  // radar filters
+  for (const type of RADAR_TYPES_KEYS) {
+    const rf = filter.radarFilters[type]
+    if (rf.min !== DEFAULTS.radarMin || rf.max !== DEFAULTS.radarMax) {
+      params.set(`r_${type}`, `${rf.min}-${rf.max}`)
+    }
+  }
+
+  // version
+  if (filter.versionFilter !== DEFAULTS.versionFilter) {
+    params.set('ver', filter.versionFilter)
+  }
+
+  // packs
+  if (filter.selectedPackIds.size > 0) {
+    params.set('pk', Array.from(filter.selectedPackIds).join(','))
+  }
+
+  // SP difficulty table
+  if (filter.selectedSpNormalKeys.size > 0) {
+    params.set('spn', Array.from(filter.selectedSpNormalKeys).join(','))
+  }
+  if (filter.selectedSpHardKeys.size > 0) {
+    params.set('sph', Array.from(filter.selectedSpHardKeys).join(','))
+  }
+
+  // DP difficulty
+  if (filter.dpDifficultyFilter.min !== DEFAULTS.dpDifficultyMin || filter.dpDifficultyFilter.max !== DEFAULTS.dpDifficultyMax) {
+    params.set('dpd', `${filter.dpDifficultyFilter.min}-${filter.dpDifficultyFilter.max}`)
+  }
+
+  // CPI filters
+  for (const clearType of CPI_CLEAR_TYPES) {
+    const cf = filter.cpiFilters[clearType]
+    if (cf.min !== DEFAULTS.cpiMin || cf.max !== DEFAULTS.cpiMax) {
+      params.set(`cpi_${clearType}`, `${cf.min}-${cf.max}`)
+    }
+  }
+
+  // sorting
+  if (sort.sorting.length > 0) {
+    const s = sort.sorting[0]
+    const defaultSort = s.id === 'title' && !s.desc
+    if (!defaultSort) {
+      params.set('sort', `${s.id}:${s.desc ? 'desc' : 'asc'}`)
+    }
+  }
+
+  // visible columns
+  if (!setsEqual(column.visibleColumns, defaultVisibleColumns)) {
+    params.set('cols', Array.from(column.visibleColumns).join(','))
+  }
+
+  // showHiddenFilters
+  if (filter.showHiddenFilters) {
+    params.set('shf', '1')
+  }
+
+  return params
+}
+
+/** URLパラメータから状態を復元 */
+function restoreFromUrl(params: URLSearchParams): boolean {
+  if (params.size === 0) return false
+
+  const chart = useChartStore.getState()
+  const filter = useFilterStore.getState()
+  const column = useColumnStore.getState()
+  const sort = useSortStore.getState()
+
+  // playMode
+  const pm = params.get('pm')
+  if (pm === 'SP' || pm === 'DP') {
+    chart.setPlayMode(pm)
+  }
+
+  // searchText
+  const q = params.get('q')
+  if (q !== null) {
+    filter.setSearchText(q)
+  }
+
+  // difficulties
+  const d = params.get('d')
+  if (d !== null) {
+    const diffs = new Set<Difficulty>(
+      d.split(',').map((s) => DIFFICULTY_SHORT_MAP[s]).filter(Boolean)
+    )
+    filter.setDifficulties(diffs)
+  }
+
+  // level
+  const lv = params.get('lv')
+  if (lv !== null) {
+    const [min, max] = lv.split('-').map(Number)
+    if (!isNaN(min) && !isNaN(max)) {
+      filter.setLevelRange(min, max)
+    }
+  }
+
+  // BPM
+  const bpm = params.get('bpm')
+  if (bpm !== null) {
+    const [min, max] = bpm.split('-')
+    filter.setBpmRange(min ?? '', max ?? '')
+  }
+
+  // noteCount
+  const nc = params.get('nc')
+  if (nc !== null) {
+    const [min, max] = nc.split('-')
+    filter.setNoteCountRange(min ?? '', max ?? '')
+  }
+
+  // radar filters
+  for (const type of RADAR_TYPES_KEYS) {
+    const rv = params.get(`r_${type}`)
+    if (rv !== null) {
+      const [min, max] = rv.split('-').map(Number)
+      if (!isNaN(min) && !isNaN(max)) {
+        filter.setRadarFilter(type, { min, max })
+      }
+    }
+  }
+
+  // version
+  const ver = params.get('ver')
+  if (ver === 'ac' || ver === 'inf' || ver === 'all') {
+    filter.setVersionFilter(ver)
+  }
+
+  // packs
+  const pk = params.get('pk')
+  if (pk !== null) {
+    const ids = new Set(pk.split(',').map(Number).filter((n) => !isNaN(n)))
+    filter.setSelectedPackIds(ids)
+  }
+
+  // SP difficulty table
+  const spn = params.get('spn')
+  if (spn !== null) {
+    // Reset then set each key
+    const keys = spn.split(',')
+    for (const key of keys) {
+      filter.toggleSpNormalKey(key)
+    }
+  }
+  const sph = params.get('sph')
+  if (sph !== null) {
+    const keys = sph.split(',')
+    for (const key of keys) {
+      filter.toggleSpHardKey(key)
+    }
+  }
+
+  // DP difficulty
+  const dpd = params.get('dpd')
+  if (dpd !== null) {
+    const [min, max] = dpd.split('-')
+    filter.setDpDifficultyFilter({ min: min ?? '', max: max ?? '' })
+  }
+
+  // CPI filters
+  for (const clearType of CPI_CLEAR_TYPES) {
+    const cv = params.get(`cpi_${clearType}`)
+    if (cv !== null) {
+      const [min, max] = cv.split('-')
+      filter.setCpiFilter(clearType as CpiClearType, { min: min ?? '', max: max ?? '' })
+    }
+  }
+
+  // sorting
+  const sortParam = params.get('sort')
+  if (sortParam !== null) {
+    const [col, dir] = sortParam.split(':')
+    if (col) {
+      sort.setSorting([{ id: col, desc: dir === 'desc' }])
+    }
+  }
+
+  // visible columns
+  const cols = params.get('cols')
+  if (cols !== null) {
+    const colIds = new Set(cols.split(',').filter(Boolean)) as Set<ColumnId>
+    // Set all columns: first hide all, then show specified ones
+    const allIds = COLUMN_CONFIGS.map((c) => c.id)
+    for (const id of allIds) {
+      column.setColumnVisible(id, colIds.has(id as ColumnId))
+    }
+  }
+
+  // showHiddenFilters
+  const shf = params.get('shf')
+  if (shf === '1') {
+    filter.setShowHiddenFilters(true)
+  }
+
+  return true
+}
+
+export function useUrlSync() {
+  const isRestoringRef = useRef(false)
+  const rafIdRef = useRef<number | null>(null)
+
+  // マウント時にURL解析 → ストアに反映
+  useLayoutEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    if (params.size > 0) {
+      isRestoringRef.current = true
+      restoreFromUrl(params)
+      // 次のフレームで復元完了フラグをクリア
+      requestAnimationFrame(() => {
+        isRestoringRef.current = false
+      })
+    }
+  }, [])
+
+  // ストア変更を監視してURL更新
+  useLayoutEffect(() => {
+    const scheduleUrlUpdate = () => {
+      if (isRestoringRef.current) return
+      if (rafIdRef.current !== null) {
+        cancelAnimationFrame(rafIdRef.current)
+      }
+      rafIdRef.current = requestAnimationFrame(() => {
+        rafIdRef.current = null
+        const params = buildSearchParams()
+        const search = params.toString()
+        const newUrl = search ? `${window.location.pathname}?${search}` : window.location.pathname
+        if (window.location.search !== `?${search}` && window.location.search !== (search ? `?${search}` : '')) {
+          window.history.replaceState(null, '', newUrl)
+        }
+      })
+    }
+
+    const unsubs = [
+      useChartStore.subscribe(scheduleUrlUpdate),
+      useFilterStore.subscribe(scheduleUrlUpdate),
+      useColumnStore.subscribe(scheduleUrlUpdate),
+      useSortStore.subscribe(scheduleUrlUpdate),
+    ]
+
+    return () => {
+      unsubs.forEach((unsub) => unsub())
+      if (rafIdRef.current !== null) {
+        cancelAnimationFrame(rafIdRef.current)
+      }
+    }
+  }, [])
+}

--- a/src/stores/columnStore.ts
+++ b/src/stores/columnStore.ts
@@ -31,6 +31,20 @@ export interface ColumnConfig {
   playMode?: 'SP' | 'DP'
 }
 
+export type ColumnGroupId = 'basic' | 'radar' | 'difficultyTable'
+
+export interface ColumnGroup {
+  id: ColumnGroupId
+  label: string
+  columnIds: ColumnId[]
+}
+
+export const COLUMN_GROUPS: ColumnGroup[] = [
+  { id: 'basic', label: '基本', columnIds: ['title', 'difficulty', 'level', 'bpm', 'noteCount'] },
+  { id: 'radar', label: 'レーダー', columnIds: ['notes', 'peak', 'scratch', 'soflan', 'charge', 'chord'] },
+  { id: 'difficultyTable', label: '難易度表', columnIds: ['spNormal', 'spHard', 'dpDifficulty', 'cpiEasy', 'cpiNormal', 'cpiHard', 'cpiExh', 'cpiFc'] },
+]
+
 export const COLUMN_CONFIGS: ColumnConfig[] = [
   { id: 'title', label: '楽曲名', defaultVisible: true, defaultVisibleMobile: true },
   { id: 'difficulty', label: '難易度', defaultVisible: true, defaultVisibleMobile: true },
@@ -60,6 +74,8 @@ interface ColumnState {
   toggleColumn: (id: ColumnId) => void
   /** カラムの表示状態を設定 */
   setColumnVisible: (id: ColumnId, visible: boolean) => void
+  /** 複数カラムの表示状態を一括設定 */
+  setColumnsVisible: (ids: ColumnId[], visible: boolean) => void
   /** デフォルトにリセット */
   resetColumns: (isMobile: boolean) => void
 }
@@ -95,6 +111,19 @@ export const useColumnStore = create<ColumnState>()(
             newColumns.add(id)
           } else {
             newColumns.delete(id)
+          }
+          return { visibleColumns: newColumns }
+        }),
+
+      setColumnsVisible: (ids, visible) =>
+        set((state) => {
+          const newColumns = new Set(state.visibleColumns)
+          for (const id of ids) {
+            if (visible) {
+              newColumns.add(id)
+            } else {
+              newColumns.delete(id)
+            }
           }
           return { visibleColumns: newColumns }
         }),

--- a/src/stores/columnStore.ts
+++ b/src/stores/columnStore.ts
@@ -31,7 +31,7 @@ export interface ColumnConfig {
   playMode?: 'SP' | 'DP'
 }
 
-export type ColumnGroupId = 'basic' | 'radar' | 'difficultyTable'
+export type ColumnGroupId = 'basic' | 'radar' | 'difficultyTable' | 'cpi'
 
 export interface ColumnGroup {
   id: ColumnGroupId
@@ -42,7 +42,8 @@ export interface ColumnGroup {
 export const COLUMN_GROUPS: ColumnGroup[] = [
   { id: 'basic', label: '基本', columnIds: ['title', 'difficulty', 'level', 'bpm', 'noteCount'] },
   { id: 'radar', label: 'レーダー', columnIds: ['notes', 'peak', 'scratch', 'soflan', 'charge', 'chord'] },
-  { id: 'difficultyTable', label: '難易度表', columnIds: ['spNormal', 'spHard', 'dpDifficulty', 'cpiEasy', 'cpiNormal', 'cpiHard', 'cpiExh', 'cpiFc'] },
+  { id: 'difficultyTable', label: '難易度表', columnIds: ['spNormal', 'spHard', 'dpDifficulty'] },
+  { id: 'cpi', label: 'CPI', columnIds: ['cpiEasy', 'cpiNormal', 'cpiHard', 'cpiExh', 'cpiFc'] },
 ]
 
 export const COLUMN_CONFIGS: ColumnConfig[] = [

--- a/src/stores/filterStore.ts
+++ b/src/stores/filterStore.ts
@@ -69,6 +69,8 @@ interface FilterState {
   cpiFilterExpanded: boolean
   /** 非表示カラムのフィルタも表示するか */
   showHiddenFilters: boolean
+  /** フィルタパネルの展開状態 */
+  filterPanelExpanded: boolean
   /** 検索テキストを設定 */
   setSearchText: (text: string) => void
   /** 難易度を切り替え */
@@ -110,6 +112,10 @@ interface FilterState {
   setCpiFilter: (clearType: CpiClearType, filter: CpiRangeFilter) => void
   /** CPIフィルタ展開を切り替え */
   toggleCpiFilterExpanded: () => void
+  /** フィルタパネルの展開を切り替え */
+  toggleFilterPanelExpanded: () => void
+  /** フィルタパネルの展開状態を設定 */
+  setFilterPanelExpanded: (expanded: boolean) => void
   /** 非表示フィルタ表示を切り替え */
   toggleShowHiddenFilters: () => void
   /** 非表示フィルタ表示を設定 */
@@ -169,6 +175,7 @@ const getInitialState = () => ({
   cpiFilters: getInitialCpiFilters(),
   cpiFilterExpanded: false,
   showHiddenFilters: false,
+  filterPanelExpanded: true,
 })
 
 /** 永続化用の型（SetをArrayに変換） */
@@ -192,6 +199,7 @@ interface PersistedFilterState {
   cpiFilters: Record<CpiClearType, CpiRangeFilter>
   cpiFilterExpanded: boolean
   showHiddenFilters: boolean
+  filterPanelExpanded: boolean
 }
 
 export const useFilterStore = create<FilterState>()(
@@ -295,6 +303,11 @@ export const useFilterStore = create<FilterState>()(
       toggleCpiFilterExpanded: () =>
         set((state) => ({ cpiFilterExpanded: !state.cpiFilterExpanded })),
 
+      toggleFilterPanelExpanded: () =>
+        set((state) => ({ filterPanelExpanded: !state.filterPanelExpanded })),
+
+      setFilterPanelExpanded: (filterPanelExpanded) => set({ filterPanelExpanded }),
+
       toggleShowHiddenFilters: () =>
         set((state) => ({ showHiddenFilters: !state.showHiddenFilters })),
 
@@ -326,6 +339,7 @@ export const useFilterStore = create<FilterState>()(
               cpiFilters: parsed.state.cpiFilters ?? getInitialCpiFilters(),
               cpiFilterExpanded: parsed.state.cpiFilterExpanded ?? false,
               showHiddenFilters: parsed.state.showHiddenFilters ?? false,
+              filterPanelExpanded: parsed.state.filterPanelExpanded ?? true,
             },
           }
         },
@@ -351,6 +365,7 @@ export const useFilterStore = create<FilterState>()(
             cpiFilters: state.cpiFilters,
             cpiFilterExpanded: state.cpiFilterExpanded,
             showHiddenFilters: state.showHiddenFilters,
+            filterPanelExpanded: state.filterPanelExpanded,
           }
           localStorage.setItem(name, JSON.stringify({ ...value, state: persistedState }))
         },
@@ -376,6 +391,7 @@ export const useFilterStore = create<FilterState>()(
         cpiFilters: state.cpiFilters,
         cpiFilterExpanded: state.cpiFilterExpanded,
         showHiddenFilters: state.showHiddenFilters,
+        filterPanelExpanded: state.filterPanelExpanded,
       }),
     }
   )

--- a/src/stores/filterStore.ts
+++ b/src/stores/filterStore.ts
@@ -100,8 +100,12 @@ interface FilterState {
   setLabels: (labels: LabelResponse) => void
   /** SPノーマル難易度キーを切り替え */
   toggleSpNormalKey: (key: string) => void
+  /** SPノーマル難易度キーを設定 */
+  setSelectedSpNormalKeys: (keys: Set<string>) => void
   /** SPハード難易度キーを切り替え */
   toggleSpHardKey: (key: string) => void
+  /** SPハード難易度キーを設定 */
+  setSelectedSpHardKeys: (keys: Set<string>) => void
   /** DP難易度表フィルターを設定 */
   setDpDifficultyFilter: (filter: DpDifficultyFilter) => void
   /** SP難易度表ラベル定義を設定（☆12/☆11をマージ） */
@@ -199,7 +203,6 @@ interface PersistedFilterState {
   cpiFilters: Record<CpiClearType, CpiRangeFilter>
   cpiFilterExpanded: boolean
   showHiddenFilters: boolean
-  filterPanelExpanded: boolean
 }
 
 export const useFilterStore = create<FilterState>()(
@@ -268,6 +271,8 @@ export const useFilterStore = create<FilterState>()(
           return { selectedSpNormalKeys: newKeys }
         }),
 
+      setSelectedSpNormalKeys: (selectedSpNormalKeys) => set({ selectedSpNormalKeys }),
+
       toggleSpHardKey: (key) =>
         set((state) => {
           const newKeys = new Set(state.selectedSpHardKeys)
@@ -278,6 +283,8 @@ export const useFilterStore = create<FilterState>()(
           }
           return { selectedSpHardKeys: newKeys }
         }),
+
+      setSelectedSpHardKeys: (selectedSpHardKeys) => set({ selectedSpHardKeys }),
 
       setDpDifficultyFilter: (dpDifficultyFilter) => set({ dpDifficultyFilter }),
 
@@ -339,7 +346,6 @@ export const useFilterStore = create<FilterState>()(
               cpiFilters: parsed.state.cpiFilters ?? getInitialCpiFilters(),
               cpiFilterExpanded: parsed.state.cpiFilterExpanded ?? false,
               showHiddenFilters: parsed.state.showHiddenFilters ?? false,
-              filterPanelExpanded: parsed.state.filterPanelExpanded ?? true,
             },
           }
         },
@@ -365,7 +371,6 @@ export const useFilterStore = create<FilterState>()(
             cpiFilters: state.cpiFilters,
             cpiFilterExpanded: state.cpiFilterExpanded,
             showHiddenFilters: state.showHiddenFilters,
-            filterPanelExpanded: state.filterPanelExpanded,
           }
           localStorage.setItem(name, JSON.stringify({ ...value, state: persistedState }))
         },
@@ -391,7 +396,6 @@ export const useFilterStore = create<FilterState>()(
         cpiFilters: state.cpiFilters,
         cpiFilterExpanded: state.cpiFilterExpanded,
         showHiddenFilters: state.showHiddenFilters,
-        filterPanelExpanded: state.filterPanelExpanded,
       }),
     }
   )

--- a/src/stores/filterStore.ts
+++ b/src/stores/filterStore.ts
@@ -67,6 +67,8 @@ interface FilterState {
   cpiFilters: Record<CpiClearType, CpiRangeFilter>
   /** CPIフィルタ展開状態 */
   cpiFilterExpanded: boolean
+  /** 非表示カラムのフィルタも表示するか */
+  showHiddenFilters: boolean
   /** 検索テキストを設定 */
   setSearchText: (text: string) => void
   /** 難易度を切り替え */
@@ -108,6 +110,10 @@ interface FilterState {
   setCpiFilter: (clearType: CpiClearType, filter: CpiRangeFilter) => void
   /** CPIフィルタ展開を切り替え */
   toggleCpiFilterExpanded: () => void
+  /** 非表示フィルタ表示を切り替え */
+  toggleShowHiddenFilters: () => void
+  /** 非表示フィルタ表示を設定 */
+  setShowHiddenFilters: (show: boolean) => void
   /** フィルタをリセット */
   resetFilters: () => void
 }
@@ -162,6 +168,7 @@ const getInitialState = () => ({
   difficultyTableFilterExpanded: false,
   cpiFilters: getInitialCpiFilters(),
   cpiFilterExpanded: false,
+  showHiddenFilters: false,
 })
 
 /** 永続化用の型（SetをArrayに変換） */
@@ -184,6 +191,7 @@ interface PersistedFilterState {
   difficultyTableFilterExpanded: boolean
   cpiFilters: Record<CpiClearType, CpiRangeFilter>
   cpiFilterExpanded: boolean
+  showHiddenFilters: boolean
 }
 
 export const useFilterStore = create<FilterState>()(
@@ -287,6 +295,11 @@ export const useFilterStore = create<FilterState>()(
       toggleCpiFilterExpanded: () =>
         set((state) => ({ cpiFilterExpanded: !state.cpiFilterExpanded })),
 
+      toggleShowHiddenFilters: () =>
+        set((state) => ({ showHiddenFilters: !state.showHiddenFilters })),
+
+      setShowHiddenFilters: (showHiddenFilters) => set({ showHiddenFilters }),
+
       resetFilters: () => set((state) => ({
         ...getInitialState(),
         labels: state.labels,
@@ -312,6 +325,7 @@ export const useFilterStore = create<FilterState>()(
               difficultyTableFilterExpanded: parsed.state.difficultyTableFilterExpanded ?? false,
               cpiFilters: parsed.state.cpiFilters ?? getInitialCpiFilters(),
               cpiFilterExpanded: parsed.state.cpiFilterExpanded ?? false,
+              showHiddenFilters: parsed.state.showHiddenFilters ?? false,
             },
           }
         },
@@ -336,6 +350,7 @@ export const useFilterStore = create<FilterState>()(
             difficultyTableFilterExpanded: state.difficultyTableFilterExpanded,
             cpiFilters: state.cpiFilters,
             cpiFilterExpanded: state.cpiFilterExpanded,
+            showHiddenFilters: state.showHiddenFilters,
           }
           localStorage.setItem(name, JSON.stringify({ ...value, state: persistedState }))
         },
@@ -360,6 +375,7 @@ export const useFilterStore = create<FilterState>()(
         difficultyTableFilterExpanded: state.difficultyTableFilterExpanded,
         cpiFilters: state.cpiFilters,
         cpiFilterExpanded: state.cpiFilterExpanded,
+        showHiddenFilters: state.showHiddenFilters,
       }),
     }
   )

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -1,4 +1,4 @@
 export { useChartStore } from './chartStore'
 export { useFilterStore } from './filterStore'
-export { useColumnStore, COLUMN_CONFIGS, type ColumnId } from './columnStore'
+export { useColumnStore, COLUMN_CONFIGS, COLUMN_GROUPS, type ColumnId, type ColumnGroupId } from './columnStore'
 export { useSortStore } from './sortStore'

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -1,4 +1,4 @@
 export { useChartStore } from './chartStore'
 export { useFilterStore } from './filterStore'
-export { useColumnStore, COLUMN_CONFIGS, COLUMN_GROUPS, type ColumnId, type ColumnGroupId } from './columnStore'
+export { useColumnStore, COLUMN_CONFIGS, COLUMN_GROUPS, type ColumnId, type ColumnGroupId, type ColumnConfig } from './columnStore'
 export { useSortStore } from './sortStore'


### PR DESCRIPTION
## Summary
- カラム設定をグループ（基本/レーダー/難易度表/CPI）単位でON/OFF可能に変更
- フィルタ表示をカラム表示状態と連動し、非表示カラムのフィルタを隠す機能を追加
- 全状態をURLパラメータに反映し、URL共有で同じ検索条件を再現可能に
- 検索条件・統計情報パネルを開閉可能に（統一デザイン）
- SP/DP切り替えをヘッダー右側に移動
- テーブル高さをビューポート残りスペースに自動フィット

## Test plan
- [ ] カラム設定でグループ単位ON/OFF、部分選択でindeterminate表示を確認
- [ ] カラム非表示→対応フィルタが消える、「非表示カラムの検索条件も表示する」ONで復活、フィルタ値が保持されることを確認
- [ ] フィルタ/ソート/カラム変更→URLが更新される、URLコピーして別タブで同じ状態が再現される
- [ ] URLパラメータなしでアクセス→localStorageから状態復元を確認
- [ ] 検索条件パネル・統計情報パネルの開閉が正常に動作することを確認
- [ ] パネルを全て閉じた場合、テーブルが縦幅を活用していることを確認
- [ ] SP/DP切り替えがヘッダー右側で正常に動作することを確認
- [ ] `npm run build` でTypeScriptエラーがないことを確認

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)